### PR TITLE
Fix erroneous temp file removal

### DIFF
--- a/src/Meter.php
+++ b/src/Meter.php
@@ -187,7 +187,7 @@ class Meter
     private function tearDownReportFile()
     {
         if ($this->reportTempFile) {
-            unlink($this->reportTempFile);
+            unlink($this->options['report']);
         }
     }
 


### PR DESCRIPTION
There was a typo causing a PHP warning.
